### PR TITLE
Se configuro la pantalla login como predeterminada 

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -8,7 +8,7 @@ import CreateNew from '../views/CreateNew.vue';
 const routes: Array<RouteRecordRaw> = [
   {
     path: '/',
-    redirect: '/home'
+    redirect: '/login'
   },
   {
     path: '/login',


### PR DESCRIPTION
Se configuró que la pantalla Login sea la primera que se muestre a la hora de lanzar el proyecto.